### PR TITLE
Add unit tests for date extraction

### DIFF
--- a/tests/test_date_correction.py
+++ b/tests/test_date_correction.py
@@ -1,0 +1,33 @@
+import os
+import sys
+from datetime import datetime
+
+import pytest
+
+# Ensure the DateCorrector module can be imported without triggering package imports
+MODULE_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'custom_components', 'ev_charging_extractor'))
+if MODULE_PATH not in sys.path:
+    sys.path.insert(0, MODULE_PATH)
+
+from date_correction_script import DateCorrector
+
+
+@pytest.mark.parametrize(
+    "provider, raw_data, expected",
+    [
+        (
+            "Tesla",
+            "Invoice date 2024/03/01\nOther text",
+            datetime(2024, 3, 1),
+        ),
+        (
+            "BP Pulse",
+            "Some text\nStart Time: Mar 25, 2024 at 10:23:00 AM\nMore text",
+            datetime(2024, 3, 25),
+        ),
+    ],
+)
+def test_extract_date_from_raw_data(provider, raw_data, expected):
+    corrector = DateCorrector(":memory:")
+    result = corrector.extract_date_from_raw_data(raw_data, provider)
+    assert result == expected


### PR DESCRIPTION
## Summary
- add tests verifying DateCorrector parses dates for Tesla and BP Pulse receipts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5baf13bd08320be22a678071311f2