### PR TITLE
Remove duplicate email search constants

### DIFF
--- a/custom_components/ev_charging_extractor/const.py
+++ b/custom_components/ev_charging_extractor/const.py
@@ -49,9 +49,6 @@ DEFAULT_SCHEDULE_MINUTE = 0
 DEFAULT_SCAN_INTERVAL = timedelta(days=1)
 MANUAL_UPDATE_INTERVAL = timedelta(minutes=5)
 
-CONF_EMAIL_SEARCH_DAYS_BACK = "email_search_days_back"
-DEFAULT_EMAIL_SEARCH_DAYS_BACK = 30  # Default 30 days
-
 # Sensor types
 SENSOR_TYPES = {
     "total_sessions": {


### PR DESCRIPTION
## Summary
- remove duplicate CONF_EMAIL_SEARCH_DAYS_BACK and DEFAULT_EMAIL_SEARCH_DAYS_BACK definitions

## Testing
- `flake8 custom_components/ev_charging_extractor/const.py` *(fails: command not found)*
- `pip install flake8` *(fails: Could not find a version that satisfies the requirement flake8)*
- `mypy custom_components/ev_charging_extractor/const.py` *(fails: missing stubs and import errors)
- `python -m py_compile custom_components/ev_charging_extractor/const.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5bad4748083208c2384216b6c36a1